### PR TITLE
Switch to new BCEL with java 8 support.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,11 +147,9 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <!-- Current bcel 5.2 does not provide support for java 8 -->
-    <!-- as soon as bcel 6.0 will be released it should be changed back to apache bcel -->
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>bcel-findbugs</artifactId>
+      <groupId>org.apache.bcel</groupId>
+      <artifactId>bcel</artifactId>
       <version>6.0</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Release notes at: https://svn.apache.org/repos/asf/commons/proper/bcel/trunk/RELEASE-NOTES.txt
